### PR TITLE
Allows all URLs to be handled by React except for /api/ and /_ah/ URLs.

### DIFF
--- a/client/src/components/page/UserPage.js
+++ b/client/src/components/page/UserPage.js
@@ -20,6 +20,7 @@ import { connect } from 'react-redux';
 
 import 'css/userPage.css';
 import { HIDDEN } from 'constants/css.js';
+import { MESSAGE } from 'constants/links.js';
 import Message from 'components/ui/Message.js';
 
 /** Gets the parameters from the url. Parameters are after the ? in the url. */
@@ -54,7 +55,7 @@ class UserPage extends Component {
 
   /** Fetches messages and add them to the page. */
   fetchMessages() {
-    const url = '/gap/messages?user=' + userEmailParam;
+    const url = MESSAGE + '?user=' + userEmailParam;
     fetch(url)
       .then(response => {
         return response.json();
@@ -81,10 +82,7 @@ class UserPage extends Component {
     return (
       <div className='container'>
         <h1 className='center'>{userEmailParam}</h1>
-        <form
-          action='/gap/messages'
-          method='POST'
-          className={hiddenIfViewingOther}>
+        <form action={MESSAGE} method='POST' className={hiddenIfViewingOther}>
           Enter a new message:
           <br />
           <textarea name='text' className='message-input' />

--- a/client/src/constants/links.js
+++ b/client/src/constants/links.js
@@ -19,15 +19,21 @@
  * Client links do not need redirect to an external server.
  */
 
+/** Prefix for all servlet fetch links. */
+const servletPrefix = '/api';
+
+/** Link to the login servlet. */
+export const LOGIN = servletPrefix + '/login';
+/** Link to the logout servlet. */
+export const LOGOUT = servletPrefix + '/logout';
+/**Link to the login status servlet. */
+export const LOGIN_STATUS = servletPrefix + '/login-status';
+/** Link to the message servlet.  */
+export const MESSAGE = servletPrefix + '/messages';
+
 /** Client link to the about page. */
 export const ABOUT_US = '/aboutus';
 /** Client link to the home page. */
 export const HOME = '/';
-/** Google App Engine link to the login servlet. */
-export const LOGIN = '/gap/login';
-/** Google App Engine link to the login status servlet. */
-export const LOGIN_STATUS = '/gap/login-status';
-/** Google App Engine link to the logout servlet. */
-export const LOGOUT = '/gap/logout';
 /** Client link to the user's page. */
 export const USER_PAGE = '/userpage';

--- a/client/src/setupProxy.js
+++ b/client/src/setupProxy.js
@@ -10,7 +10,7 @@ const proxy = require('http-proxy-middleware');
 
 module.exports = function(app) {
   /** Proxies calls to our Google App Engine. */
-  app.use(proxy('/gap/*', { target: 'http://localhost:8080/' }));
+  app.use(proxy('/api/*', { target: 'http://localhost:8080/' }));
   /** Proxies calls to the Google Login Server. */
   app.use(proxy('/_ah/*', { target: 'http://localhost:8080/' }));
 };

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -18,10 +18,10 @@ The [Redux](https://redux.js.org/) library is used to help keep state on the cli
 
 When the client makes web requests to the server, a servlet will pick up the request. A servlet knows what requests to intercept by an annotation we provide it.
 
-For example, the login servlet below intercepts the url `localhost:8080/gap/login`, where `localhost:8080` will be replaced by the actual live website url when deployed through app engine.
+For example, the login servlet below intercepts the url `localhost:8080/api/login`, where `localhost:8080` will be replaced by the actual live website url when deployed through app engine.
 
 ```
-@WebServlet("/gap/login")
+@WebServlet("/api/login")
 public class LoginServlet extends HttpServlet {
   @Override
   public void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException {}

--- a/server/src/main/java/com/google/codeu/filters/SinglePageAppFilter.java
+++ b/server/src/main/java/com/google/codeu/filters/SinglePageAppFilter.java
@@ -1,0 +1,39 @@
+import java.io.IOException;
+import javax.servlet.Filter;
+import javax.servlet.FilterChain;
+import javax.servlet.FilterConfig;
+import javax.servlet.RequestDispatcher;
+import javax.servlet.ServletException;
+import javax.servlet.ServletRequest;
+import javax.servlet.ServletResponse;
+import javax.servlet.annotation.WebFilter;
+import javax.servlet.http.HttpServletRequest;
+
+/** Filters all paths back to index.html due to SPA client structure. */
+@WebFilter("/*")
+public class SinglePageAppFilter implements Filter {
+  @Override
+  public void init(FilterConfig filterConfig) {}
+
+  @Override
+  public void destroy() {}
+
+  @Override
+  public void doFilter(
+      ServletRequest servletRequest, ServletResponse servletResponse, FilterChain filterChain)
+      throws IOException, ServletException {
+    String path = ((HttpServletRequest) servletRequest).getServletPath();
+
+    // Continue to servlets architecture if the prefix matches:
+    // 1. Servlet Request (api)
+    // 2. Google Request (_ah)
+    if (path.startsWith("/api") || path.startsWith("/_ah")) {
+      filterChain.doFilter(servletRequest, servletResponse);
+    } else {
+      // Redirects back to index.html if the request wasn't intended for a
+      // servlet.
+      RequestDispatcher dispatcher = servletRequest.getRequestDispatcher("/");
+      dispatcher.forward(servletRequest, servletResponse);
+    }
+  }
+}

--- a/server/src/main/java/com/google/codeu/servlets/LoginServlet.java
+++ b/server/src/main/java/com/google/codeu/servlets/LoginServlet.java
@@ -25,7 +25,7 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
 /** Redirects the user to the Google login page or their page if they're already logged in. */
-@WebServlet("/gap/login")
+@WebServlet("/api/login")
 public class LoginServlet extends HttpServlet {
 
   @Override
@@ -42,7 +42,7 @@ public class LoginServlet extends HttpServlet {
 
     // Redirect to Google login page. That page will then redirect back to /login,
     // which will be handled by the above if statement.
-    String googleLoginUrl = userService.createLoginURL("/gap/login");
+    String googleLoginUrl = userService.createLoginURL("/api/login");
     response.sendRedirect(googleLoginUrl);
   }
 }

--- a/server/src/main/java/com/google/codeu/servlets/LoginStatusServlet.java
+++ b/server/src/main/java/com/google/codeu/servlets/LoginStatusServlet.java
@@ -28,7 +28,7 @@ import javax.servlet.http.HttpServletResponse;
 /**
  * Returns login data as JSON, e.g. {"isLoggedIn": true, "username": "alovelace@codeustudents.com"}
  */
-@WebServlet("/gap/login-status")
+@WebServlet("/api/login-status")
 public class LoginStatusServlet extends HttpServlet {
 
   @Override

--- a/server/src/main/java/com/google/codeu/servlets/LogoutServlet.java
+++ b/server/src/main/java/com/google/codeu/servlets/LogoutServlet.java
@@ -25,7 +25,7 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
 /** Redirects the user to the Google logout page, which then redirects to the homepage. */
-@WebServlet("/gap/logout")
+@WebServlet("/api/logout")
 public class LogoutServlet extends HttpServlet {
 
   @Override

--- a/server/src/main/java/com/google/codeu/servlets/MessageServlet.java
+++ b/server/src/main/java/com/google/codeu/servlets/MessageServlet.java
@@ -31,7 +31,7 @@ import org.jsoup.Jsoup;
 import org.jsoup.safety.Whitelist;
 
 /** Handles fetching and saving {@link Message} instances. */
-@WebServlet("/gap/messages")
+@WebServlet("/api/messages")
 public class MessageServlet extends HttpServlet {
 
   private Datastore datastore;


### PR DESCRIPTION
All urls such as localhost:8080/aboutus will redirect to React for routing.
Previously, Google App Engine (GAE) would redirect /aboutus to a servlet, and
since no servlet handled /aboutus, GAE would throw a 404 error. Now React can
also handle bad links.

Issue: https://github.com/fluffysheep-codeu/Summer2019-Team30/issues/29
PR: https://github.com/fluffysheep-codeu/Summer2019-Team30/pull/30