### PR TITLE
Translate Button on Public Feed to Translate All Messages

### DIFF
--- a/client/src/components/page/PublicFeed.js
+++ b/client/src/components/page/PublicFeed.js
@@ -15,7 +15,7 @@
  */
 
 import React, { Component } from 'react';
-import { MESSAGE_FEED_SERVLET } from 'constants/links.js';
+import { MESSAGE_FEED_SERVLET, TRANSLATION_SERVLET } from 'constants/links.js';
 import Message from 'components/ui/Message.js';
 import { HIDDEN } from 'constants/css.js';
 
@@ -47,6 +47,37 @@ class PublicFeed extends Component {
       });
   }
 
+  /** Translates the text of an individual message and updates state */
+  buildTranslatedMessages(content, index, languageCode) {
+    const url =
+      TRANSLATION_SERVLET +
+      '?text=' +
+      content.text.toString() +
+      '&languageCode=' +
+      languageCode.toString();
+    fetch(url, {
+      method: 'POST'
+    })
+      .then(response => response.text())
+      .then(translatedMessage => {
+        content.text = translatedMessage;
+        const new_messages = this.state.content;
+        new_messages[index] = content;
+        this.setState({ content: new_messages });
+      });
+  }
+
+  /** Called by clicking the button and translates all the messages and updates state */
+  requestTranslation(languageCode) {
+    const messages = this.state.content;
+    const translatedMessages = messages
+      ? messages.map((content, index) =>
+          this.buildTranslatedMessages(content, index, languageCode)
+        )
+      : null;
+    this.setState({ translatedMessages });
+  }
+
   render() {
     const value = this.state.content;
     const messageList = value
@@ -59,6 +90,22 @@ class PublicFeed extends Component {
         <div className={hideIfFullyLoaded}>Loading...</div>
         <hr />
         <ul>{messageList}</ul>
+
+        <select id='language'>
+          <option value='es'>English</option>
+          <option value='zh'>Chinese</option>
+          <option value='es'>Spanish</option>
+          <option value='hi'>Hindi</option>
+          <option value='ar'>Arabic</option>
+        </select>
+        <button
+          onClick={e =>
+            this.requestTranslation(
+              document.getElementById('language', e).value
+            )
+          }>
+          Translate
+        </button>
       </div>
     );
   }

--- a/client/src/constants/links.js
+++ b/client/src/constants/links.js
@@ -36,6 +36,8 @@ export const STATS_SERVLET = servletPrefix + '/stats';
 export const COMMUNITY_PAGE_SERVLET = servletPrefix + '/user-list';
 /** Link to the MESSAGE FEED servlet. */
 export const MESSAGE_FEED_SERVLET = servletPrefix + '/feed';
+/** Link to the TRANSLATION servlet. */
+export const TRANSLATION_SERVLET = servletPrefix + '/translate';
 
 export const MESSAGE_FEED = '/feed';
 /** Client link to the about page. */

--- a/server/pom.xml
+++ b/server/pom.xml
@@ -63,6 +63,13 @@ limitations under the License.
       <scope>compile</scope>
     </dependency>
 
+    <dependency>
+      <groupId>com.google.cloud</groupId>
+      <artifactId>google-cloud-translate</artifactId>
+      <version>1.55.0</version>
+    </dependency>
+
+
   </dependencies>
 
   <build>

--- a/server/src/main/java/com/google/codeu/servlets/TranslationServlet.java
+++ b/server/src/main/java/com/google/codeu/servlets/TranslationServlet.java
@@ -1,0 +1,32 @@
+package com.google.codeu.servlets;
+
+import com.google.cloud.translate.Translate;
+import com.google.cloud.translate.TranslateOptions;
+import com.google.cloud.translate.Translation;
+import java.io.IOException;
+import javax.servlet.annotation.WebServlet;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+@WebServlet("/api/translate")
+public class TranslationServlet extends HttpServlet {
+
+  @Override
+  public void doPost(HttpServletRequest request, HttpServletResponse response) throws IOException {
+    // Get the request parameters.
+    String originalText = request.getParameter("text");
+    String languageCode = request.getParameter("languageCode");
+
+    // Do the translation.
+    Translate translate = TranslateOptions.getDefaultInstance().getService();
+    Translation translation =
+        translate.translate(originalText, Translate.TranslateOption.targetLanguage(languageCode));
+    String translatedText = translation.getTranslatedText();
+
+    // Output the translation.
+    response.setContentType("text/html; charset=UTF-8");
+    response.setCharacterEncoding("UTF-8");
+    response.getWriter().println(translatedText);
+  }
+}


### PR DESCRIPTION
Added a button on the public feed page that will translate the text of every message into another language. 

Issue: https://github.com/fluffysheep-codeu/Summer2019-Team30/issues/44
PR: https://github.com/fluffysheep-codeu/Summer2019-Team30/pull/72

Note: It will not translate any messages that aren't proper english (like helloooo)
<img width="783" alt="Screen Shot 2019-06-09 at 7 27 44 PM" src="https://user-images.githubusercontent.com/17011394/59165685-9993e700-8aed-11e9-9bba-057e900acf51.png">
<img width="926" alt="Screen Shot 2019-06-09 at 7 31 33 PM" src="https://user-images.githubusercontent.com/17011394/59165686-9ac51400-8aed-11e9-80dd-6494451047f4.png">

