### PR TITLE
Fixes failed to execute json on Response on UserPage error

### DIFF
--- a/client/src/components/page/UserPage.js
+++ b/client/src/components/page/UserPage.js
@@ -59,7 +59,7 @@ class UserPage extends Component {
 
   componentDidMount() {
     promises
-      .then(results => Promise.all(results.map(r => r.json())))
+      .then(results => Promise.all(results.map(r => r.clone().json())))
       .then(results => {
         const [messages, about] = results;
         this.setState({ messages, about });


### PR DESCRIPTION
Error on userpage if you swapped between the userpage and another page.
![image](https://user-images.githubusercontent.com/2661665/59560078-6dcaa280-8fc0-11e9-8aa2-66c070753428.png)

After this fix, the userpage shows up properly. I assume this was caused by an error with reusing the response variable from multiple fetches.

![image](https://user-images.githubusercontent.com/2661665/59560086-96529c80-8fc0-11e9-952f-3f4c5f80ef5e.png)


https://stackoverflow.com/questions/53511974/javascript-fetch-failed-to-execute-json-on-response-body-stream-is-locked