### PR TITLE
Fixed UserItem components need a unique key in Community Page

### DIFF
--- a/client/src/components/page/CommunityPage.js
+++ b/client/src/components/page/CommunityPage.js
@@ -4,7 +4,7 @@ import UserItem from 'components/ui/UserItem.js';
 
 /** Returns the html representation of a single user. */
 const buildUserListItem = function(user) {
-  return <UserItem content={user} />;
+  return <UserItem key={user} content={user} />;
 };
 
 /** Renders the community page. */


### PR DESCRIPTION
Fixed this error occurring in the console on the Community Page:
![image](https://user-images.githubusercontent.com/2661665/59560150-feee4900-8fc1-11e9-80af-e3f4be604669.png)

After this change, the error no longer appears. It is ok to use the user's email as the key since the user email is unique between each user.

Issue: None
PR: https://github.com/fluffysheep-codeu/Summer2019-Team30/pull/77