### PR TITLE
Storing Users who Sign In and Displaying on Community Page

### DIFF
--- a/client/src/components/page/CommunityPage.js
+++ b/client/src/components/page/CommunityPage.js
@@ -35,7 +35,7 @@ class CommunityPage extends Component {
     return (
       <div id='content' style={{ margin: 5 }}>
         <h1>Community Page</h1>
-        <p>Here is a list of every user who has posted a message:</p>
+        <p>Here is a list of every user who has logged in:</p>
         <hr />
         <ul>{userListUI}</ul>
       </div>

--- a/client/src/components/page/UserPage.js
+++ b/client/src/components/page/UserPage.js
@@ -74,6 +74,7 @@ class UserPage extends Component {
     // A boolean that checks whether the current logged in user is viewing
     // another user's page. Some controls such as the message form will hide if
     // the user is not viewing their own page.
+
     const hiddenIfViewingOther = userEmail !== userEmailParam ? HIDDEN : null;
     const hiddenIfHasMessages = messages > 0 ? HIDDEN : null;
 

--- a/server/src/main/java/com/google/codeu/data/Datastore.java
+++ b/server/src/main/java/com/google/codeu/data/Datastore.java
@@ -148,13 +148,13 @@ public class Datastore {
     return results.countEntities(FetchOptions.Builder.withLimit(MESSAGE_LIMIT));
   }
 
-  /** Returns a list of all the users that have sent messages. */
+  /** Returns a list of all the users that have signed in. */
   public List<String> getUsers() {
     List<String> users = new ArrayList<>();
-    Query query = new Query("Message");
+    Query query = new Query("User");
     PreparedQuery results = datastore.prepare(query);
     for (Entity entity : results.asIterable()) {
-      String name = (String) entity.getProperty("user");
+      String name = (String) entity.getProperty("email");
       if (!(users.contains(name))) {
         users.add(name);
       }

--- a/server/src/main/java/com/google/codeu/servlets/LoginServlet.java
+++ b/server/src/main/java/com/google/codeu/servlets/LoginServlet.java
@@ -18,15 +18,26 @@ package com.google.codeu.servlets;
 
 import com.google.appengine.api.users.UserService;
 import com.google.appengine.api.users.UserServiceFactory;
+import com.google.codeu.data.Datastore;
+import com.google.codeu.data.User;
 import java.io.IOException;
 import javax.servlet.annotation.WebServlet;
 import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
-/** Redirects the user to the Google login page or their page if they're already logged in. */
+/**
+ * Redirects the user to the Google login page or their page if they're already
+ * logged in.
+ */
 @WebServlet("/api/login")
 public class LoginServlet extends HttpServlet {
+  private Datastore datastore;
+
+  @Override
+  public void init() {
+    datastore = new Datastore();
+  }
 
   @Override
   public void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException {
@@ -36,6 +47,12 @@ public class LoginServlet extends HttpServlet {
     // If the user is already logged in, redirect to their page
     if (userService.isUserLoggedIn()) {
       String user = userService.getCurrentUser().getEmail();
+      // stores the user in datastore if it's their first time signing in
+      // TODO(brianch): Refactor User to use builder pattern
+      if (datastore.getUser(user) == null) {
+        User newUser = new User(user, "");
+        datastore.storeUser(newUser);
+      }
       response.sendRedirect("/userpage?user=" + user);
       return;
     }


### PR DESCRIPTION
Instead of storing users when they send a message, this stores every user who logs in and displays their email on the Community Page

Issue: https://github.com/fluffysheep-codeu/Summer2019-Team30/issues/88
PR: https://github.com/fluffysheep-codeu/Summer2019-Team30/pull/91
<img width="1245" alt="Screen Shot 2019-06-25 at 8 58 58 PM" src="https://user-images.githubusercontent.com/17011394/60144945-6494bf00-9792-11e9-91db-8f2c131805f5.png">
<img width="1245" alt="Screen Shot 2019-06-25 at 8 59 17 PM" src="https://user-images.githubusercontent.com/17011394/60144948-66f71900-9792-11e9-85bc-95f0af8c7b2e.png">
